### PR TITLE
Update dietpi-software to add URL redirect to Pi-home /admin page

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3595,6 +3595,10 @@ _EOF_
 					G_DIETPI-NOTIFY 2 'Bullseye upgrade detected: Removing obsolete socket version string from FPM module'
 					G_EXEC sed -i 's/php.\..-fpm\.sock/php-fpm.sock/' /etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf
 				fi
+
+				# All distros: configure redirect to Pi-hole /admin page
+				G_EXEC sed -i '/^server\.port*/a url.redirect                = ("^/$" => "/admin" )' /etc/lighttpd/lighttpd.conf
+
 			fi
 
 			# perl is required for lighty-enable-mod, it has been degraded to recommends only with Buster.


### PR DESCRIPTION
Small addition to add URL redirect to Pi-hole /admin page instead of displaying lighttpd's default index.lighttpd.html page

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
